### PR TITLE
Add health check and status monitoring workflows

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,0 +1,50 @@
+name: Health Check
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'  # Run every 15 minutes
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  health-check:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.11'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install requests
+    
+    - name: Run health check
+      run: python scripts/health_check.py ${{ secrets.APP_URL }}
+      continue-on-error: true
+    
+    - name: Create health check issue if failed
+      if: failure()
+      uses: actions/github-script@v6
+      with:
+        script: |
+          github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: '🚨 Health Check Failed',
+            body: `Health check failed at ${new Date().toISOString()}\nPlease check the service status.`,
+            labels: ['incident', 'automated']
+          })
+    
+    - name: Notify on Slack
+      if: failure()
+      uses: 8398a7/action-slack@v3
+      with:
+        status: ${{ job.status }}
+        fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      continue-on-error: true

--- a/.github/workflows/status-monitor.yml
+++ b/.github/workflows/status-monitor.yml
@@ -1,0 +1,87 @@
+name: Status Monitor
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'  # Run every 30 minutes
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.11'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install requests psutil
+    
+    - name: Run status check
+      id: status
+      run: |
+        OUTPUT=$(python scripts/status_check.py ${{ secrets.APP_URL }})
+        echo "status_output<<EOF" >> $GITHUB_ENV
+        echo "$OUTPUT" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+    
+    - name: Update status badge
+      uses: schneegans/dynamic-badges-action@v1.6.0
+      with:
+        auth: ${{ secrets.GIST_SECRET }}
+        gistID: ${{ secrets.GIST_ID }}
+        filename: cloud_native_app_status.json
+        label: status
+        message: ${{ job.status }}
+        color: ${{ job.status == 'success' && 'success' || 'critical' }}
+    
+    - name: Create status report
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const date = new Date().toISOString();
+          const status = process.env.status_output;
+          
+          // Create or update status report issue
+          const issues = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ['status-report'],
+            state: 'open'
+          });
+          
+          const body = `## Status Report (${date})
+          \`\`\`json
+          ${status}
+          \`\`\``;
+          
+          if (issues.data.length > 0) {
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issues.data[0].number,
+              body: body
+            });
+          } else {
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '📊 Service Status Report',
+              body: body,
+              labels: ['status-report']
+            });
+          }
+    
+    - name: Send metrics to CloudWatch
+      if: false  # Disabled by default, enable if using AWS
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+      # Add CloudWatch metrics push here if needed

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ jinja2==3.1.2
 python-multipart==0.0.6
 pytest==7.4.3
 httpx==0.25.2
+requests==2.31.0
+psutil==5.9.5

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import requests
+import sys
+from datetime import datetime
+
+def check_health(url):
+    try:
+        response = requests.get(f"{url}/health")
+        health_data = response.json()
+        
+        print(f"[{datetime.now().isoformat()}] Health Check Results:")
+        print(f"Status Code: {response.status_code}")
+        print(f"Status: {health_data.get('status', 'unknown')}")
+        print(f"Version: {health_data.get('version', 'unknown')}")
+        
+        if response.status_code == 200 and health_data.get('status') == 'healthy':
+            print("✅ Service is healthy")
+            return 0
+        else:
+            print("❌ Service is unhealthy")
+            return 1
+    except Exception as e:
+        print(f"❌ Error checking health: {str(e)}")
+        return 1
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python health_check.py <service_url>")
+        sys.exit(1)
+    
+    service_url = sys.argv[1]
+    sys.exit(check_health(service_url))

--- a/scripts/status_check.py
+++ b/scripts/status_check.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+import requests
+import sys
+import psutil
+import json
+from datetime import datetime
+
+def get_system_metrics():
+    cpu_percent = psutil.cpu_percent(interval=1)
+    memory = psutil.virtual_memory()
+    disk = psutil.disk_usage('/')
+    
+    return {
+        "timestamp": datetime.now().isoformat(),
+        "cpu_usage_percent": cpu_percent,
+        "memory_usage_percent": memory.percent,
+        "disk_usage_percent": disk.percent,
+        "memory_available_mb": round(memory.available / (1024 * 1024), 2),
+        "disk_free_gb": round(disk.free / (1024 * 1024 * 1024), 2)
+    }
+
+def check_service_status(url):
+    try:
+        # Check main endpoint
+        root_response = requests.get(url)
+        health_response = requests.get(f"{url}/health")
+        
+        metrics = get_system_metrics()
+        
+        status = {
+            "service": {
+                "root_endpoint": {
+                    "status_code": root_response.status_code,
+                    "healthy": root_response.status_code == 200
+                },
+                "health_endpoint": {
+                    "status_code": health_response.status_code,
+                    "response": health_response.json(),
+                    "healthy": health_response.status_code == 200
+                }
+            },
+            "system_metrics": metrics
+        }
+        
+        print(json.dumps(status, indent=2))
+        
+        # Return 0 if both endpoints are healthy
+        if status["service"]["root_endpoint"]["healthy"] and status["service"]["health_endpoint"]["healthy"]:
+            print("✅ All service endpoints are responding")
+            return 0
+        else:
+            print("❌ Some service endpoints are not responding correctly")
+            return 1
+            
+    except Exception as e:
+        print(f"❌ Error checking service status: {str(e)}")
+        return 1
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python status_check.py <service_url>")
+        sys.exit(1)
+    
+    service_url = sys.argv[1]
+    sys.exit(check_service_status(service_url))


### PR DESCRIPTION
# Health Check Workflow (runs every 15 minutes):
- Checks the /health endpoint
- Creates GitHub issues for failures
- Sends Slack notifications (when configured)
- Can be triggered manually
# Status Monitor Workflow (runs every 30 minutes):
- Monitors system metrics (CPU, memory, disk)
- Checks all service endpoints
- Updates status badge
- Creates/updates status report issues
- Optional CloudWatch metrics integration